### PR TITLE
Add Ollama provider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,24 @@ export OPENAI_API_KEY="your-api-key-here"
 > export <provider>_BASE_URL="https://your-provider-api-base-url"
 > ```
 
+> ### Running a local model with Ollama
+>
+> [Ollama](https://ollama.ai) lets you host models locally. Start the server:
+>
+> ```bash
+> ollama serve        # or `ollama run mistral` to download and run a model
+> ```
+>
+> Invoke Codex with the Ollama provider:
+>
+> ```bash
+> codex --provider ollama "your prompt"
+> ```
+>
+> You can also set `model_provider = "ollama"` in `~/.codex/config.toml`. An API
+> key is not required when using Ollama locally so long as the server is running
+> at `http://localhost:11434/v1`.
+
 </details>
 <br />
 
@@ -449,6 +467,23 @@ Below is a comprehensive example of `config.json` with multiple custom providers
   }
 }
 ```
+
+For a local setup using Ollama:
+
+```json
+{
+  "model": "mistral",
+  "provider": "ollama",
+  "providers": {
+    "ollama": {
+      "name": "Ollama",
+      "baseURL": "http://localhost:11434/v1"
+    }
+  }
+}
+```
+
+No API key is needed when running Ollama locally.
 
 ### Custom instructions
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -75,7 +75,7 @@ const cli = meow(
 
     -h, --help                      Show usage and exit
     -m, --model <model>             Model to use for completions (default: codex-mini-latest)
-    -p, --provider <provider>       Provider to use for completions (default: openai)
+    -p, --provider <provider>       Provider to use for completions (default: openai, use "ollama" for a local model)
     -i, --image <path>              Path(s) to image files to include as input
     -v, --view <rollout>            Inspect a previously saved rollout instead of starting a session
     --history                       Browse previous sessions

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -31,6 +31,14 @@ model = "mistral"
 model_provider = "ollama"
 ```
 
+Make sure the Ollama server is running:
+
+```bash
+ollama serve        # or `ollama run mistral`
+```
+
+No API key is required when using a local Ollama instance.
+
 because the following definition for `ollama` is included in Codex:
 
 ```toml


### PR DESCRIPTION
## Summary
- document how to run Codex with a local Ollama server
- show ollama usage in config docs and examples
- tweak CLI help text for provider flag

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm test` *(fails: vitest not found)*
- `pnpm typecheck` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6852c6471df4832ab6fba7a41273405b