### PR TITLE
Add LangChain provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - xai
 > - groq
 > - arceeai
+- langchain
 > - any other provider that is compatible with the OpenAI API
 >
 > If you use a provider other than OpenAI, you will need to set the API key for the provider in the config file or in the environment variable as:
@@ -458,6 +459,11 @@ Below is a comprehensive example of `config.json` with multiple custom providers
       "name": "ArceeAI",
       "baseURL": "https://conductor.arcee.ai/v1",
       "envKey": "ARCEEAI_API_KEY"
+    },
+    "langchain": {
+      "name": "LangChain",
+      "baseURL": "http://localhost:8000",
+      "envKey": "LANGCHAIN_API_KEY"
     }
   },
   "history": {
@@ -508,6 +514,9 @@ export AZURE_OPENAI_API_VERSION="2025-03-01-preview" (Optional)
 
 # OpenRouter
 export OPENROUTER_API_KEY="your-openrouter-key-here"
+
+# LangChain
+export LANGCHAIN_API_KEY="your-langchain-key-here"
 
 # Similarly for other providers
 ```

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -52,4 +52,9 @@ export const providers: Record<
     baseURL: "https://conductor.arcee.ai/v1",
     envKey: "ARCEEAI_API_KEY",
   },
+  langchain: {
+    name: "LangChain",
+    baseURL: "http://localhost:8000",
+    envKey: "LANGCHAIN_API_KEY",
+  },
 };


### PR DESCRIPTION
## Summary
- add a new `langchain` provider in the provider list
- document the new provider and environment variable in README

## Testing
- `pnpm test` *(fails: rawExec – abort kills entire process group)*
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6852d0f9f284832a912c47b6433b2134