### PR TITLE
Add LangSmith tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ export LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
 
 # Similarly for other providers
 ```
-For more details on using LangChain and LangSmith with Codex CLI see
+For more details on using LangChain and LangSmith with Codex CLI and to try the example scripts see
 [docs/langsmith.md](docs/langsmith.md).
 
 ---

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -19,6 +19,8 @@ import {
   OPENAI_PROJECT,
   getBaseUrl,
   AZURE_OPENAI_API_VERSION,
+  LANGCHAIN_TRACING_V2,
+  LANGCHAIN_ENDPOINT,
 } from "../config.js";
 import { log } from "../logger/log.js";
 import { parseToolCallArguments } from "../parsers.js";
@@ -355,10 +357,10 @@ export class AgentLoop {
     setSessionId(this.sessionId);
     setCurrentModel(this.model);
 
-    if (
-      process.env["LANGCHAIN_TRACING_V2"] === "true" ||
-      process.env["LANGSMITH_TRACING_V2"] === "true"
-    ) {
+    if (LANGCHAIN_TRACING_V2 === "true" || process.env["LANGSMITH_TRACING_V2"] === "true") {
+      if (LANGCHAIN_ENDPOINT && !process.env["LANGCHAIN_ENDPOINT"]) {
+        process.env["LANGCHAIN_ENDPOINT"] = LANGCHAIN_ENDPOINT;
+      }
       try {
         // Wrap OpenAI client for LangSmith tracing
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/codex-cli/src/utils/openai-client.ts
+++ b/codex-cli/src/utils/openai-client.ts
@@ -9,6 +9,8 @@ import {
   OPENAI_PROJECT,
 } from "./config.js";
 import OpenAI, { AzureOpenAI } from "openai";
+import { wrapOpenAI } from "langsmith/wrappers/openai";
+import { log } from "./logger/log.js";
 
 type OpenAIClientConfig = {
   provider: string;
@@ -32,20 +34,35 @@ export function createOpenAIClient(
     headers["OpenAI-Project"] = OPENAI_PROJECT;
   }
 
+  let client: OpenAI | AzureOpenAI;
   if (config.provider?.toLowerCase() === "azure") {
-    return new AzureOpenAI({
+    client = new AzureOpenAI({
       apiKey: getApiKey(config.provider),
       baseURL: getBaseUrl(config.provider),
       apiVersion: AZURE_OPENAI_API_VERSION,
       timeout: OPENAI_TIMEOUT_MS,
       defaultHeaders: headers,
     });
+  } else {
+    client = new OpenAI({
+      apiKey: getApiKey(config.provider),
+      baseURL: getBaseUrl(config.provider),
+      timeout: OPENAI_TIMEOUT_MS,
+      defaultHeaders: headers,
+    });
   }
 
-  return new OpenAI({
-    apiKey: getApiKey(config.provider),
-    baseURL: getBaseUrl(config.provider),
-    timeout: OPENAI_TIMEOUT_MS,
-    defaultHeaders: headers,
-  });
+  if (
+    process.env["LANGCHAIN_TRACING_V2"] === "true" ||
+    process.env["LANGSMITH_TRACING_V2"] === "true"
+  ) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client = wrapOpenAI(client as any);
+    } catch (err) {
+      log(`Failed to enable LangSmith tracing: ${String(err)}`);
+    }
+  }
+
+  return client;
 }

--- a/docs/langsmith.md
+++ b/docs/langsmith.md
@@ -18,7 +18,7 @@ Add the `langchain` provider to your `~/.codex/config.json` if it is not already
 }
 ```
 
-Set the following environment variables (in `.env` or `~/.codex.env`) to enable tracing:
+Set the following environment variables (in `.env` or `~/.codex.env`) to enable tracing. With these set, every OpenAI API call can be captured by LangSmith:
 
 ```bash
 export LANGCHAIN_API_KEY="your-langsmith-key"
@@ -28,4 +28,8 @@ export LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
 
 ## Example scripts
 
-See [codex-cli/examples/langchain](../codex-cli/examples/langchain) for small Python examples that use LangChain. When the variables above are set, interactions will appear in your LangSmith dashboard.
+See [codex-cli/examples/langchain](../codex-cli/examples/langchain) for small Python examples that use LangChain. When the variables above are set, interactions will appear in your LangSmith dashboard. For instance, to run the RAG demo:
+
+```bash
+python codex-cli/examples/langchain/rag_pipeline.py docs "What is codex?"
+```


### PR DESCRIPTION
## Summary
- wrap OpenAI clients with LangSmith when tracing is enabled
- surface LANGCHAIN env vars in agent loop
- expand docs with LangSmith example usage

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852daf2eff4832ab7319709dffa87a5