### PR TITLE
Add Ollama LangSmith config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Non-interactive / CI mode](#non-interactive--ci-mode)
 - [Tracing / verbose logging](#tracing--verbose-logging)
 - [LangChain & LangSmith](docs/langsmith.md)
+- [Ollama + LangSmith example](docs/ollama-langsmith.md)
 - [Recipes](#recipes)
 - [Installation](#installation)
 - [Configuration guide](#configuration-guide)

--- a/docs/example-configs/ollama-langsmith.env
+++ b/docs/example-configs/ollama-langsmith.env
@@ -1,0 +1,4 @@
+# LangSmith tracing
+LANGCHAIN_API_KEY="your-langsmith-key"
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"

--- a/docs/example-configs/ollama-langsmith.json
+++ b/docs/example-configs/ollama-langsmith.json
@@ -1,0 +1,10 @@
+{
+  "model": "mistral",
+  "provider": "ollama",
+  "providers": {
+    "ollama": {
+      "name": "Ollama",
+      "baseURL": "http://localhost:11434/v1"
+    }
+  }
+}

--- a/docs/ollama-langsmith.md
+++ b/docs/ollama-langsmith.md
@@ -1,0 +1,31 @@
+# Ollama with LangSmith tracing
+
+This example shows how to configure Codex CLI to use a local model served by [Ollama](https://ollama.ai) while capturing requests in your LangSmith dashboard.
+
+Save the configuration below as `~/.codex/config.json` (also available at
+`docs/example-configs/ollama-langsmith.json`):
+
+```json
+{
+  "model": "mistral",
+  "provider": "ollama",
+  "providers": {
+    "ollama": {
+      "name": "Ollama",
+      "baseURL": "http://localhost:11434/v1"
+    }
+  }
+}
+```
+
+Then create an `.env` file (or `~/.codex.env`) with the following variables
+(see `docs/example-configs/ollama-langsmith.env`):
+
+```bash
+# LangSmith tracing
+LANGCHAIN_API_KEY="your-langsmith-key"
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
+```
+
+When these environment variables are present, Codex CLI will wrap OpenAI calls with LangSmith tracing so interactions appear on your LangSmith account.


### PR DESCRIPTION
## Summary
- document how to combine Ollama with LangSmith tracing
- include example config and `.env` files
- link new example from README

## Testing
- `pnpm test && pnpm run lint && pnpm run typecheck` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e76451ac832a979f4884d025e0c4