### PR TITLE
Add browser-use integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ export OPENAI_API_KEY="your-api-key-here"
 </details>
 <br />
 
+### Browser automation (experimental)
+
+```bash
+pip install browser-use
+playwright install chromium --with-deps --no-shell
+```
+
+Run a browser task:
+
+```bash
+codex --browse "open https://example.com and summarize the page"
+```
+
+
 Run interactively:
 
 ```shell
@@ -241,6 +255,7 @@ The hardening mechanism Codex uses depends on your OS:
 | `codex "..."`                        | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
 | `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
 | `codex completion <bash\|zsh\|fish>` | Print shell completion script       | `codex completion bash`              |
+| `codex --browse "..."`               | Run a browser-use task                | `codex --browse "open https://example.com"` |
 
 Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
 

--- a/codex-cli/browser/browser_agent.py
+++ b/codex-cli/browser/browser_agent.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Run a browser-use agent for Codex."""
+
+import asyncio
+import sys
+
+from browser_use import Agent
+from langchain_openai import ChatOpenAI
+
+async def main() -> int:
+    if len(sys.argv) < 3:
+        print("Usage: browser_agent.py <model> <task>", file=sys.stderr)
+        return 1
+    model = sys.argv[1]
+    task = " ".join(sys.argv[2:])
+
+    agent = Agent(task=task, llm=ChatOpenAI(model=model))
+    history = await agent.run()
+    # Print the final result if available
+    if history.final_result:
+        print(history.final_result)
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -31,6 +31,7 @@ import SessionsOverlay from "./components/sessions-overlay.js";
 import { AgentLoop } from "./utils/agent/agent-loop";
 import { ReviewDecision } from "./utils/agent/review";
 import { AutoApprovalMode } from "./utils/auto-approval-mode";
+import { runBrowserTask } from "./utils/browser-task.js";
 import { checkForUpdates } from "./utils/check-updates";
 import {
   loadConfig,
@@ -193,6 +194,10 @@ const cli = meow(
         choices: ["low", "medium", "high"],
         default: "high",
       },
+      browse: {
+        type: "string",
+        description: "Run a browser-use task and exit",
+      },
       // Notification
       notify: {
         type: "boolean",
@@ -256,6 +261,12 @@ complete -c codex -a '(__fish_complete_path)' -d 'file path'`,
 // For --help, show help and exit.
 if (cli.flags.help) {
   cli.showHelp();
+}
+
+// For --browse, run a browser-use task and exit.
+if (cli.flags.browse) {
+  runBrowserTask(cli.flags.browse);
+  process.exit(0);
 }
 
 // For --config, open custom instructions file in editor and exit.
@@ -363,7 +374,7 @@ if (cli.flags.free) {
 }
 
 // Set of providers that don't require API keys
-const NO_API_KEY_REQUIRED = new Set(["ollama"]);
+const NO_API_KEY_REQUIRED = new Set(["ollama", "browser"]);
 
 // Skip API key validation for providers that don't require an API key
 if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {

--- a/codex-cli/src/utils/browser-task.ts
+++ b/codex-cli/src/utils/browser-task.ts
@@ -1,0 +1,16 @@
+import { spawnSync } from "child_process";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+export function runBrowserTask(task: string, model: string = "gpt-3.5-turbo"): void {
+  const script = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../browser/browser_agent.py",
+  );
+  const result = spawnSync("python3", [script, model, task], {
+    stdio: "inherit",
+  });
+  if (result.error) {
+    throw result.error;
+  }
+}

--- a/codex-cli/src/utils/openai-client.ts
+++ b/codex-cli/src/utils/openai-client.ts
@@ -8,9 +8,9 @@ import {
   OPENAI_ORGANIZATION,
   OPENAI_PROJECT,
 } from "./config.js";
-import OpenAI, { AzureOpenAI } from "openai";
-import { wrapOpenAI } from "langsmith/wrappers/openai";
 import { log } from "./logger/log.js";
+import { wrapOpenAI } from "langsmith/wrappers/openai";
+import OpenAI, { AzureOpenAI } from "openai";
 
 type OpenAIClientConfig = {
   provider: string;

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -57,4 +57,9 @@ export const providers: Record<
     baseURL: "http://localhost:8000",
     envKey: "LANGCHAIN_API_KEY",
   },
+  browser: {
+    name: "BrowserUse",
+    baseURL: "",
+    envKey: "BROWSER_USE_API_KEY",
+  },
 };

--- a/codex-cli/tests/browser-task.test.ts
+++ b/codex-cli/tests/browser-task.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from "vitest";
+import { runBrowserTask } from "../src/utils/browser-task.js";
+import { spawnSync } from "child_process";
+
+vi.mock("child_process", () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}));
+
+describe("runBrowserTask", () => {
+  it("spawns python script", () => {
+    runBrowserTask("test-task");
+    expect(spawnSync).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- integrate `browser-use` library
- add browser automation docs
- new browser provider and CLI `--browse` flag
- wrap python agent for browser tasks
- include basic tests

## Testing
- `pnpm test` *(fails: Process with PID failed to terminate)*
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6852db78b32c832a8461546d2b239fb9